### PR TITLE
`exclude` + `exclude-known-generated-files` args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,59 @@
+## 1.1.0
+
+- ⚠️ Breaking change: `exclude-suffix` arg no longer has a default values with generated files pattern.
+- New `exclude-known-generated-files` arg.
+- New `exclude` arg, that uses [Glob syntax](https://pub.dev/packages/glob#syntax), replacing `exclude-suffix`
+  and `exclude-prefix` args
+- `exclude-suffix` and `exclude-prefix` no longer listed as args. Any usage of them will print a warning message
+
 ## 1.0.4
+
 - Fix analysis not working when project was not in the root of git repository
 - Warnings messages when `.git` or `/lib` ware not found
 - `stdin-timeout` argument
 
 ## 1.0.3+1
+
 - readme fixes
 
 ## 1.0.3
-- `fully-tested-message` param: you can now set a custom output message to be displayed when there is no untested lines
 
+- `fully-tested-message` arg: you can now set a custom output message to be displayed when there is no untested lines
 
 ## 1.0.2+1
+
 - Updating example
 
 ## 1.0.2
+
 - Adding "Number of lines that should be tested under `/lib`"
 
 ## 1.0.1
+
 - Removing total of new lines from output because it is a completely useless information
 - Fixes on readme
 
-
 ## 1.0.0
+
 - Stable release
 
 ## 0.0.6+1
+
 - Updating readme 💃
 
 ## 0.0.6
+
 - Ending report is now a table
 
 ## 0.0.5
-- new `fraction-digits` param
-- new `markdown-mode` param
+
+- new `fraction-digits` arg
+- new `markdown-mode` arg
 
 ## 0.0.4
 
 - ⚠️ "use-colorful-font" replaced by "use-colorful-output", since it depends on the output type now
 - New markdown output type
-
 
 ## 0.0.3+2
 
@@ -51,9 +66,9 @@
 
 ## 0.0.3
 
-- ⚠️ "hide-uncovered-lines" param replaced by "show-uncovered-code", which is now a boolean
-- new "use-colorful-font" param.
-- new "report-fully-covered-files" param.
+- ⚠️ "hide-uncovered-lines" arg replaced by "show-uncovered-code", which is now a boolean
+- new "use-colorful-font" arg.
+- new "report-fully-covered-files" arg.
 - removed emojis from the output
 
 ## 0.0.2+1

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Default value within parenthesis
 
 ### File filter
 
-- **exclude-suffix** (`.g.dart,.pb.dart,.pbenum.dart,.pbserver.dart,.pbjson.dart`): Exclude all file paths that end with those suffixes, separated by commas
+- **exclude**: exclude files that matches with the [widely-known Bash glob syntax](https://pub.dev/packages/glob#syntax), separated by commas. Ex: `--exclude '/lib/di/**','**/gen.dart'`.
 
-- **exclude-prefix** : Exclude all paths that start with those prefixes, separated by commas
+- **exclude-known-generated-files** (`true`) : Exclude file paths that ends with `.g.dart`, `.pb.dart`, `.pbenum.dart`, `.pbserver.dart` or `.pbjson.dart`
 
 #### Presentation
 

--- a/bin/pull_request_coverage.dart
+++ b/bin/pull_request_coverage.dart
@@ -22,6 +22,7 @@ import 'package:pull_request_coverage/src/presentation/output_print_generator/cl
 import 'package:pull_request_coverage/src/presentation/output_print_generator/markdown_output_generator.dart';
 import 'package:pull_request_coverage/src/presentation/output_print_generator/output_generator.dart';
 import 'package:pull_request_coverage/src/presentation/use_case/colorize_cli_text.dart';
+import 'package:pull_request_coverage/src/presentation/use_case/print_deprecated_args_warnning.dart';
 import 'package:pull_request_coverage/src/presentation/use_case/print_result_for_file.dart';
 import 'package:pull_request_coverage/src/presentation/use_case/print_warnings_for_unexpected_file_structre.dart';
 
@@ -73,6 +74,8 @@ Future<void> main(List<String> arguments) async {
   final lcovLines = await _getOrFailLcovLines(userOptions.lcovFilePath);
   final colorizeText = ColorizeCliText(userOptions.useColorfulOutput);
   final outputGenerator = _getOutputGenerator(userOptions, colorizeText);
+
+  PrintDeprecatedArgsWarning(print, colorizeText)(userOptions);
 
   PrintWarningsForUnexpectedFileStructure(print, colorizeText)(
     gitRootRelativePath: gitRootRelativePath,

--- a/lib/src/data/user_options/user_options_repository_impl.dart
+++ b/lib/src/data/user_options/user_options_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:args/args.dart';
+import 'package:glob/glob.dart';
 import 'package:pull_request_coverage/src/domain/common/result.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/markdown_mode.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/output_mode.dart';
@@ -7,7 +8,13 @@ import 'package:pull_request_coverage/src/domain/user_options/repositories/user_
 
 class UserOptionsRepositoryImpl implements UserOptionsRepository {
   static const defaultLcovFile = "coverage/lcov.info";
-  static const defaultExcludeSuffix = ".g.dart,.pb.dart,.pbenum.dart,.pbserver.dart,.pbjson.dart";
+  static const knownGeneratedFiles = [
+    '**.g.dart',
+    '**.pb.dart',
+    '**.pbenum.dart',
+    '**.pbserver.dart',
+    '**.pbjson.dart',
+  ];
 
   final ArgParser argParser;
 
@@ -27,14 +34,23 @@ class UserOptionsRepositoryImpl implements UserOptionsRepository {
       defaultsTo: defaultLcovFile,
     );
     argParser.addOption(
+      // deprecated
       "exclude-suffix",
       help: "Exclude files path with those suffix, separated by comma",
-      defaultsTo: defaultExcludeSuffix,
     );
     argParser.addOption(
+      // deprecated
       "exclude-prefix",
       help: "Exclude files path with those prefix, separated by comma",
-      defaultsTo: defaultLcovFile,
+    );
+    argParser.addOption(
+      "exclude-known-generated-files",
+      help: "Exclude all $knownGeneratedFiles files",
+      defaultsTo: "true",
+    );
+    argParser.addOption(
+      "exclude",
+      help: "Exclude files path that matches with Glob pattern, separate by comma",
     );
     argParser.addOption(
       "minimum-coverage",
@@ -79,28 +95,51 @@ class UserOptionsRepositoryImpl implements UserOptionsRepository {
     );
   }
 
+  List<Glob> _parseGlob(List<String> patterns) {
+    try {
+      return List.generate(patterns.length, (index) => Glob(patterns[index]), growable: false);
+    } catch (e) {
+      throw Exception("Glob parser error: $e");
+    }
+  }
+
+  List<Glob> _parseExclude(ArgResults argResults) {
+    final excludeKnownGeneratedFiles = argResults["exclude-known-generated-files"] == "true";
+    final prefixes = (argResults["exclude-prefix"] as String?)?.split(",").toList(growable: false) ?? [];
+    final suffixes = (argResults["exclude-suffix"] as String?)?.split(",").toList(growable: false) ?? [];
+    final exclude = (argResults["exclude"] as String?)?.split(",").toList(growable: false) ?? [];
+    return [
+      if (excludeKnownGeneratedFiles) ..._parseGlob(knownGeneratedFiles),
+      ..._parseGlob(prefixes.map((pattern) => "$pattern**").toList(growable: false)),
+      ..._parseGlob(exclude),
+      ..._parseGlob(suffixes.map((pattern) => "**$pattern").toList(growable: false)),
+    ];
+  }
+
   @override
   Result<UserOptions> getUserOptions(List<String> arguments) {
     try {
       _registerAvailableOptions();
-      final result = argParser.parse(arguments);
+      final argResults = argParser.parse(arguments);
 
       return ResultSuccess(
         UserOptions(
-          excludePrefixPaths: result["exclude-prefix"]?.toLowerCase().split(",").toList(growable: false) ?? [],
-          excludeSuffixPaths: result["exclude-suffix"]?.toLowerCase().split(",").toList(growable: false) ?? [],
-          lcovFilePath: result["lcov-file"],
-          minimumCoverageRate: result["minimum-coverage"] != null ? double.tryParse(result["minimum-coverage"]) : null,
-          maximumUncoveredLines:
-              result["maximum-uncovered-lines"] != null ? int.tryParse(result["maximum-uncovered-lines"]) : null,
-          showUncoveredCode: result["show-uncovered-code"] == "true",
-          useColorfulOutput: result["use-colorful-output"] == "true",
-          reportFullyCoveredFiles: result["report-fully-covered-files"] == "true",
-          outputMode: result["output-mode"] == "markdown" ? OutputMode.markdown : OutputMode.cli,
-          fractionalDigits: int.tryParse(result["fraction-digits"]) ?? 2,
-          markdownMode: result["markdown-mode"] == "dart" ? MarkdownMode.dart : MarkdownMode.diff,
-          fullyTestedMessage: result["fully-tested-message"],
-          stdinTimeout: Duration(seconds: int.tryParse(result["stdin-timeout"]) ?? 1),
+          excludeFile: _parseExclude(argResults),
+          lcovFilePath: argResults["lcov-file"],
+          minimumCoverageRate:
+              argResults["minimum-coverage"] != null ? double.tryParse(argResults["minimum-coverage"]) : null,
+          maximumUncoveredLines: argResults["maximum-uncovered-lines"] != null
+              ? int.tryParse(argResults["maximum-uncovered-lines"])
+              : null,
+          showUncoveredCode: argResults["show-uncovered-code"] == "true",
+          useColorfulOutput: argResults["use-colorful-output"] == "true",
+          reportFullyCoveredFiles: argResults["report-fully-covered-files"] == "true",
+          outputMode: argResults["output-mode"] == "markdown" ? OutputMode.markdown : OutputMode.cli,
+          fractionalDigits: int.tryParse(argResults["fraction-digits"]) ?? 2,
+          markdownMode: argResults["markdown-mode"] == "dart" ? MarkdownMode.dart : MarkdownMode.diff,
+          fullyTestedMessage: argResults["fully-tested-message"],
+          stdinTimeout: Duration(seconds: int.tryParse(argResults["stdin-timeout"]) ?? 1),
+          deprecatedFilterSet: argResults["exclude-prefix"] != null || argResults["exclude-suffix"] != null,
         ),
       );
     } catch (e) {

--- a/lib/src/domain/analyser/use_case/should_analyse_this_file.dart
+++ b/lib/src/domain/analyser/use_case/should_analyse_this_file.dart
@@ -3,9 +3,11 @@ import 'package:pull_request_coverage/src/domain/user_options/models/user_option
 class ShouldAnalyseThisFile {
   final UserOptions userOptions;
 
-  ShouldAnalyseThisFile(this.userOptions);
+  const ShouldAnalyseThisFile(this.userOptions);
 
   bool call(String filePath) {
-    return filePath.endsWith(".dart") && filePath.startsWith("lib/") && !userOptions.excludePrefixPaths.any(filePath.startsWith) && !userOptions.excludeSuffixPaths.any(filePath.endsWith);
+    return filePath.endsWith(".dart") &&
+        filePath.startsWith("lib/") &&
+        !userOptions.excludeFile.any((glob) => glob.matches(filePath));
   }
 }

--- a/lib/src/domain/user_options/models/user_options.dart
+++ b/lib/src/domain/user_options/models/user_options.dart
@@ -1,9 +1,9 @@
+import 'package:glob/glob.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/markdown_mode.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/output_mode.dart';
 
 class UserOptions {
-  final List<String> excludePrefixPaths;
-  final List<String> excludeSuffixPaths;
+  final List<Glob> excludeFile;
   final String lcovFilePath;
   final String? fullyTestedMessage;
   final double? minimumCoverageRate;
@@ -15,11 +15,11 @@ class UserOptions {
   final MarkdownMode markdownMode;
   final int fractionalDigits;
   final Duration stdinTimeout;
+  final bool deprecatedFilterSet;
 
   /// [fractionalDigits] how many digits after the decimal point to show on coverage rate
   const UserOptions({
-    required this.excludePrefixPaths,
-    required this.excludeSuffixPaths,
+    required this.excludeFile,
     required this.lcovFilePath,
     required this.showUncoveredCode,
     required this.outputMode,
@@ -31,5 +31,6 @@ class UserOptions {
     this.useColorfulOutput = true,
     this.reportFullyCoveredFiles = true,
     this.stdinTimeout = const Duration(seconds: 1),
+    this.deprecatedFilterSet = false,
   });
 }

--- a/lib/src/presentation/use_case/print_deprecated_args_warnning.dart
+++ b/lib/src/presentation/use_case/print_deprecated_args_warnning.dart
@@ -1,0 +1,27 @@
+import 'package:pull_request_coverage/src/domain/user_options/models/user_options.dart';
+import 'package:pull_request_coverage/src/presentation/use_case/colorize_cli_text.dart';
+
+class PrintDeprecatedArgsWarning {
+  final void Function(String message) print;
+  final ColorizeCliText colorizeText;
+
+  const PrintDeprecatedArgsWarning(this.print, this.colorizeText);
+
+  void call(UserOptions userOptions) {
+    if (userOptions.deprecatedFilterSet) {
+      print(colorizeText(
+        r'''
+        [WARNING] `exclude-prefix` and `exclude-suffix` args are now deprecated. (but still works ;-)
+                  use `exclude` instead. It receive a list of Glob syntaxt, closely to the widely-known Bash glob syntax: 
+                  https://pub.dev/packages/glob#syntax, so:
+                       - replace `--exclude-prefix `bla,ble` by `--exclude 'bla**',ble**'
+                       - replace `--exclude-suffix `bla,ble` by `--exclude '**bla',**ble'
+        
+                  `exclude-suffix` no longer has a default values with generated files pattern. 
+                  Now, there is `exclude-known-generated-files` that defaults to true.
+        ''',
+        TextColor.yellow,
+      ));
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pull_request_coverage
 description: A CLI tool to verify the test coverage of a pull request only, ignoring the rest of the project.
 repository: https://github.com/talesbarreto/pull_request_coverage
-version: 1.0.4
+version: 1.1.0
 
 executables:
   pull_request_coverage:
@@ -12,6 +12,7 @@ environment:
 dependencies:
   args: ^2.3.1
   file: ^6.1.4
+  glob: ^2.1.1
 
 dev_dependencies:
   test: ^1.22.2


### PR DESCRIPTION
- ⚠️ Breaking change: `exclude-suffix` arg no longer has a default values with generated files pattern.
- New `exclude-known-generated-files` arg.
- New `exclude` arg, that uses [Glob syntax](https://pub.dev/packages/glob#syntax), replacing `exclude-suffix`
  and `exclude-prefix` args
- `exclude-suffix` and `exclude-prefix` no longer listed as args. Any usage of them will print a warning message
- Readme changes
- Setting version to 1.1.0