### PR TITLE
New `approval-requirement` threshold option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- New `approval-requirement` option
+
 ## 2.0.0
 
 - Output has emojis now. You can disable them by setting `print-emojis` to `false`.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Default values are indicated in parentheses.
 
 - **maximum-uncovered-lines** : Specifies the maximum number of uncovered lines allowed before the tests fail.
 
+- **approval-requirement** (`lines-and-rate`): when both, `minimum-coverage` and `maximum-uncovered-lines`, are specified, the `approval-requirement` determines the conditions for passing the tests. 
+  - `lines-and-rate`: both conditions must be met to pass the tests.
+  - `lines-or-rate:` only one of the conditions must be met to pass the tests.
+
 ### Filters
 
 - **ignore**: list of files that should be ignored, using the [widely-known Bash glob syntax](https://pub.dev/packages/glob#syntax). The cumulative count of ignored lines from these files will be shown in the report for statistical purposes only.

--- a/lib/src/data/user_options/user_options_repository_impl.dart
+++ b/lib/src/data/user_options/user_options_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:file/file.dart';
 import 'package:glob/glob.dart';
 import 'package:pull_request_coverage/src/data/user_options/data_source/arg_data_source.dart';
 import 'package:pull_request_coverage/src/data/user_options/data_source/yaml_data_source.dart';
+import 'package:pull_request_coverage/src/domain/user_options/models/approval_requirement.dart';
 import 'package:pull_request_coverage/src/domain/user_options/user_option_register.dart';
 import 'package:pull_request_coverage/src/domain/common/result.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/markdown_mode.dart';
@@ -76,6 +77,16 @@ class UserOptionsRepositoryImpl implements UserOptionsRepository {
     }
   }
 
+  ApprovalRequirement _parseApprovalRequirement(String? string) {
+    switch (string) {
+      case "lines-or-rate":
+        return ApprovalRequirement.linesOrRate;
+      case "lines-and-rate":
+      default:
+        return ApprovalRequirement.linesAndRate;
+    }
+  }
+
   @override
   Result<UserOptions> getUserOptions(List<String> arguments) {
     final arg = argGetters;
@@ -94,7 +105,8 @@ class UserOptionsRepositoryImpl implements UserOptionsRepository {
           reportFullyCoveredFiles: arg.getBooleanOrDefault(UserOptionRegister.reportFullyCoveredFiles),
           outputMode: arg.getString(UserOptionRegister.outputMode) == "markdown" ? OutputMode.markdown : OutputMode.cli,
           fractionalDigits: arg.getInt(UserOptionRegister.fractionDigits) ?? 2,
-          markdownMode: arg.getString(UserOptionRegister.markdownMode) == "dart" ? MarkdownMode.dart : MarkdownMode.diff,
+          markdownMode:
+              arg.getString(UserOptionRegister.markdownMode) == "dart" ? MarkdownMode.dart : MarkdownMode.diff,
           fullyTestedMessage: arg.getString(UserOptionRegister.fullyTestedMessage),
           stdinTimeout: Duration(seconds: arg.getInt(UserOptionRegister.stdinTimeout) ?? 1),
           deprecatedFilterSet: false,
@@ -106,6 +118,7 @@ class UserOptionsRepositoryImpl implements UserOptionsRepository {
             ..._parseGlob(arg.getStringList(UserOptionRegister.addToKnownGeneratedFiles) ?? []),
           ],
           useEmojis: arg.getBooleanOrDefault(UserOptionRegister.printEmojis),
+          approvalRequirement: _parseApprovalRequirement(arg.getString(UserOptionRegister.approvalRequirement)),
           logLevel: _parseLogLevel(arg.getString(UserOptionRegister.logLevel)),
         ),
       );

--- a/lib/src/domain/analyzer/models/analysis_result.dart
+++ b/lib/src/domain/analyzer/models/analysis_result.dart
@@ -2,15 +2,11 @@ class AnalysisResult {
   final int linesThatShouldBeTested;
   final int linesMissingTests;
   final int untestedIgnoredLines;
-  final int? linesMissingTestsThreshold;
-  final double? coverageRateThreshold;
   final double coverageRate;
 
   const AnalysisResult({
     required this.linesThatShouldBeTested,
     required this.linesMissingTests,
     required this.untestedIgnoredLines,
-    required this.linesMissingTestsThreshold,
-    required this.coverageRateThreshold,
   }) : coverageRate = 1 - (linesMissingTests / linesThatShouldBeTested);
 }

--- a/lib/src/domain/analyzer/use_case/analyze.dart
+++ b/lib/src/domain/analyzer/use_case/analyze.dart
@@ -63,8 +63,6 @@ class Analyze {
         linesThatShouldBeTested: totalOfLinesThatShouldBeTested,
         untestedIgnoredLines: totalUntestedIgnoredLines,
         linesMissingTests: totalOfLinesMissingTests,
-        linesMissingTestsThreshold: userOptions.maximumUncoveredLines,
-        coverageRateThreshold: userOptions.minimumCoverageRate,
       ),
     );
   }

--- a/lib/src/domain/analyzer/use_case/get_exit_code.dart
+++ b/lib/src/domain/analyzer/use_case/get_exit_code.dart
@@ -1,19 +1,25 @@
 import 'package:pull_request_coverage/src/domain/analyzer/models/analysis_result.dart';
 import 'package:pull_request_coverage/src/domain/analyzer/models/exit_code.dart';
+import 'package:pull_request_coverage/src/domain/user_options/models/approval_requirement.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/user_options.dart';
 
 class GetExitCode {
+  const GetExitCode();
+
   int call(AnalysisResult analysisResult, UserOptions userOptions) {
-    if (userOptions.minimumCoverageRate != null &&
-        analysisResult.coverageRate < (userOptions.minimumCoverageRate! / 100)) {
-      return ExitCode.testFail;
-    }
+    final minimumCoverageFailRateIsSet = userOptions.minimumCoverageRate != null;
+    final maximumUncoveredLinesFailIsSet = userOptions.maximumUncoveredLines != null;
 
-    if (userOptions.maximumUncoveredLines != null &&
-        analysisResult.linesMissingTests > userOptions.maximumUncoveredLines!) {
-      return ExitCode.testFail;
-    }
+    final minimumCoverageFail =
+        minimumCoverageFailRateIsSet && analysisResult.coverageRate < (userOptions.minimumCoverageRate! / 100);
+    final maximumUncoveredLinesFail =
+        maximumUncoveredLinesFailIsSet && analysisResult.linesMissingTests > userOptions.maximumUncoveredLines!;
 
-    return ExitCode.noErrorsFounds;
+    if (userOptions.approvalRequirement == ApprovalRequirement.linesOrRate &&
+        minimumCoverageFailRateIsSet &&
+        maximumUncoveredLinesFailIsSet) {
+      return maximumUncoveredLinesFail && minimumCoverageFail ? ExitCode.testFail : ExitCode.noErrorsFounds;
+    }
+    return maximumUncoveredLinesFail || minimumCoverageFail ? ExitCode.testFail : ExitCode.noErrorsFounds;
   }
 }

--- a/lib/src/domain/user_options/models/approval_requirement.dart
+++ b/lib/src/domain/user_options/models/approval_requirement.dart
@@ -1,0 +1,4 @@
+enum ApprovalRequirement {
+  linesAndRate,
+  linesOrRate,
+}

--- a/lib/src/domain/user_options/models/user_options.dart
+++ b/lib/src/domain/user_options/models/user_options.dart
@@ -1,4 +1,5 @@
 import 'package:glob/glob.dart';
+import 'package:pull_request_coverage/src/domain/user_options/models/approval_requirement.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/markdown_mode.dart';
 import 'package:pull_request_coverage/src/domain/user_options/models/output_mode.dart';
 import 'package:pull_request_coverage/src/presentation/logger/log_level.dart';
@@ -21,6 +22,7 @@ class UserOptions {
   final Duration stdinTimeout;
   final bool deprecatedFilterSet;
   final List<RegExp> lineFilters;
+  final ApprovalRequirement approvalRequirement;
   final LogLevel logLevel;
 
   /// [fractionalDigits] how many digits after the decimal point to show on coverage rate
@@ -43,5 +45,6 @@ class UserOptions {
     this.lineFilters = const [],
     this.useEmojis = true,
     this.logLevel = LogLevel.none,
+    this.approvalRequirement = ApprovalRequirement.linesAndRate,
   });
 }

--- a/lib/src/domain/user_options/user_option_register.dart
+++ b/lib/src/domain/user_options/user_option_register.dart
@@ -1,3 +1,4 @@
+import 'package:pull_request_coverage/src/domain/user_options/models/approval_requirement.dart';
 import 'package:pull_request_coverage/src/presentation/logger/log_level.dart';
 
 class UserOptionRegister<T> {
@@ -39,6 +40,7 @@ class UserOptionRegister<T> {
     addToKnownGeneratedFiles,
     knownGeneratedFiles,
     printEmojis,
+    approvalRequirement,
     logLevel,
   ];
 
@@ -158,6 +160,14 @@ class UserOptionRegister<T> {
     names: ["print-emojis"],
     description: "Use emojis in the output",
     defaultValue: true,
+  );
+
+  static const approvalRequirement = UserOptionRegister<ApprovalRequirement>(
+    names: ["approval-requirement"],
+    description:
+        "when both minimum-coverage and maximum-uncovered-lines are specified, the approval-requirement determines the conditions for passing the tests.",
+    defaultValue: ApprovalRequirement.linesAndRate,
+    allowed: ["lines-and-rate", "lines-or-rate"],
   );
 
   static const logLevel = UserOptionRegister<LogLevel>(

--- a/test/src/domain/analyzer/use_case/get_exit_code_test.dart
+++ b/test/src/domain/analyzer/use_case/get_exit_code_test.dart
@@ -1,0 +1,176 @@
+import 'package:pull_request_coverage/src/domain/analyzer/models/analysis_result.dart';
+import 'package:pull_request_coverage/src/domain/analyzer/models/exit_code.dart';
+import 'package:pull_request_coverage/src/domain/analyzer/use_case/get_exit_code.dart';
+import 'package:pull_request_coverage/src/domain/user_options/models/approval_requirement.dart';
+import 'package:pull_request_coverage/src/domain/user_options/models/user_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const exitCode = GetExitCode();
+  group("when `ApprovalRequirement` is set to `linesAndRate`", () {
+    group("approve when", () {
+      test("coverage rate is 90, limit is 80. Uncovered lines is 4 and its limit is 15", () {
+        final options = UserOptions(
+          minimumCoverageRate: 80,
+          maximumUncoveredLines: 15,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+
+      test("coverage rate is 90, limit is 80. Uncovered lines is 4 and there is no line limit", () {
+        final options = UserOptions(
+          minimumCoverageRate: 80,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+
+      test(" Uncovered lines is 15, its limit is 16 and there is no rate limit", () {
+        final options = UserOptions(
+          maximumUncoveredLines: 16,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 9100,
+          linesMissingTests: 15,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+    });
+
+    group("fail when", () {
+      test("coverage rate is 90, limit is 90. Uncovered lines is 10 and its limit is 9", () {
+        final options = UserOptions(
+          minimumCoverageRate: 90,
+          maximumUncoveredLines: 9,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.testFail);
+      });
+
+      test("coverage rate is 84, limit is 80. Uncovered lines is 16 and its limit is 15", () {
+        final options = UserOptions(
+          minimumCoverageRate: 80,
+          maximumUncoveredLines: 15,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 16,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.testFail);
+      });
+
+      test("coverage rate is 84, limit is 85. Uncovered lines is 16 and there is no line limit", () {
+        final options = UserOptions(
+          minimumCoverageRate: 85,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 16,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.testFail);
+      });
+
+      test("Uncovered lines is 10, limit is 9 and there is no rate limit", () {
+        final options = UserOptions(
+          maximumUncoveredLines: 9,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.testFail);
+      });
+    });
+  });
+
+  group("when `ApprovalRequirement` is set to `linesOrRate`", () {
+    group("approve when", () {
+      test("coverage rate is 90, limit is 80. Uncovered lines is 4 and its limit is 15", () {
+        final options = UserOptions(
+          minimumCoverageRate: 80,
+          maximumUncoveredLines: 15,
+          approvalRequirement: ApprovalRequirement.linesOrRate,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+
+      test("coverage rate is 90, limit is 80. Uncovered lines is 4 and there is no line limit", () {
+        final options = UserOptions(
+          minimumCoverageRate: 80,
+          approvalRequirement: ApprovalRequirement.linesOrRate,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+
+      test("coverage rate is 90, limit is 90. Uncovered lines is 10 and its limit is 9", () {
+        final options = UserOptions(
+          minimumCoverageRate: 90,
+          maximumUncoveredLines: 9,
+          approvalRequirement: ApprovalRequirement.linesOrRate,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+
+      test("Uncovered lines is 15, its limit is 16 and there is no rate limit", () {
+        final options = UserOptions(
+          maximumUncoveredLines: 16,
+          approvalRequirement: ApprovalRequirement.linesOrRate,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 9100,
+          linesMissingTests: 15,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.noErrorsFounds);
+      });
+    });
+
+    group("fail when", () {
+      test("coverage rate is 90, limit is 91. Uncovered lines is 10 and its limit is 3", () {
+        final options = UserOptions(
+          minimumCoverageRate: 91,
+          maximumUncoveredLines: 3,
+          approvalRequirement: ApprovalRequirement.linesOrRate,
+        );
+        final result = AnalysisResult(
+          linesThatShouldBeTested: 100,
+          linesMissingTests: 10,
+          untestedIgnoredLines: 0,
+        );
+        expect(exitCode(result, options), ExitCode.testFail);
+      });
+    });
+  });
+}

--- a/test/src/presentation/output_generator/text_output_generator_test.dart
+++ b/test/src/presentation/output_generator/text_output_generator_test.dart
@@ -47,8 +47,6 @@ void main() {
         linesThatShouldBeTested: 12,
         linesMissingTests: 0,
         untestedIgnoredLines: 0,
-        linesMissingTestsThreshold: null,
-        coverageRateThreshold: null,
       );
 
       testGenerator(
@@ -77,8 +75,6 @@ void main() {
         linesThatShouldBeTested: 12,
         linesMissingTests: 1,
         untestedIgnoredLines: 0,
-        linesMissingTestsThreshold: null,
-        coverageRateThreshold: null,
       );
 
       testGenerator(


### PR DESCRIPTION
- **approval-requirement** (`lines-and-rate`): when both, `minimum-coverage` and `maximum-uncovered-lines`, are specified, the `approval-requirement` determines the conditions for passing the tests. 
  - `lines-and-rate`: both conditions must be met to pass the tests.
  - `lines-or-rate:` only one of the conditions must be met to pass the tests.

_ A new weird option to make @pftupina happy_